### PR TITLE
feature/hidden-events: Working prototype for hidden events

### DIFF
--- a/backend/modules/event/graphql-controller.js
+++ b/backend/modules/event/graphql-controller.js
@@ -106,6 +106,20 @@ class EventController {
         )
     }
 
+    getActiveButNotHidden() {
+        return this._clean(
+            Event.find({
+                published: true,
+                endTime: {
+                    $gte: new Date(),
+                },
+                eventType: 'online' || 'physical',
+            })
+                .sort([['startTime', 1]])
+                .lean(),
+        )
+    }
+
     getPast() {
         return this._clean(
             Event.find({

--- a/backend/modules/event/graphql.js
+++ b/backend/modules/event/graphql.js
@@ -211,6 +211,14 @@ const QueryType = new GraphQLObjectType({
                 },
             },
         },
+        activeButNotHidden: {
+            type: GraphQLList(EventType),
+            args: {
+                limit: {
+                    type: GraphQLInt,
+                },
+            },
+        },
         pastEvents: {
             type: GraphQLList(EventType),
             args: {
@@ -260,6 +268,17 @@ const Resolvers = {
             }
             return events
         },
+        activeButNotHidden: async (parent, args, context) => {
+            let events = await context
+                .controller('Event')
+                .getActiveButNotHidden()
+            if (args.limit) {
+                events = events.slice(0, args.limit)
+            }
+
+            return events
+        },
+
         pastEvents: async (parents, args, context) => {
             let events = await context.controller('Event').getPast()
             if (args.limit) {

--- a/frontend/src/components/navbars/GlobalNavBar/index.js
+++ b/frontend/src/components/navbars/GlobalNavBar/index.js
@@ -32,11 +32,13 @@ export default () => {
     return (
         <div className={classes.wrapper}>
             <div className={classes.inner}>
-                <a href="/"><img
-                    src={config.LOGO_DARK_URL}
-                    className={classes.wordmark}
-                    alt={config.PLATFORM_OWNER_NAME + ' logo'}
-                /></a>
+                <a href="/">
+                    <img
+                        src={config.LOGO_DARK_URL}
+                        className={classes.wordmark}
+                        alt={config.PLATFORM_OWNER_NAME + ' logo'}
+                    />
+                </a>
                 <Grid className={classes.inner}>
                     <UserMenu />
                     <Hidden only="xs">

--- a/frontend/src/graphql/queries/events.js
+++ b/frontend/src/graphql/queries/events.js
@@ -79,6 +79,24 @@ export const useActiveEvents = ({ limit }) => {
     return [data?.activeEvents, loading, error]
 }
 
+export const GET_ACTIVE_BUT_NOT_HIDDEN = gql`
+    query Event {
+        activeButNotHidden {
+            ...EventPreview
+        }
+    }
+    ${Fragments.EventPreview}
+`
+export const useActiveButNotHidden = ({ limit }) => {
+    const { data, loading, error } = useQuery(GET_ACTIVE_BUT_NOT_HIDDEN, {
+        variables: {
+            limit,
+        },
+    })
+
+    return [data?.activeButNotHidden, loading, error]
+}
+
 export const GET_PAST_EVENTS = gql`
     query Event($limit: Int) {
         pastEvents(limit: $limit) {

--- a/frontend/src/pages/_index/index.js
+++ b/frontend/src/pages/_index/index.js
@@ -12,7 +12,11 @@ import CenteredContainer from 'components/generic/CenteredContainer'
 import GlobalNavBar from 'components/navbars/GlobalNavBar'
 import config from 'constants/config'
 
-import { useActiveEvents, usePastEvents } from 'graphql/queries/events'
+import {
+    useActiveEvents,
+    usePastEvents,
+    useActiveButNotHidden,
+} from 'graphql/queries/events'
 import { useAllOrganizations } from 'graphql/queries/organization'
 import { Helmet } from 'react-helmet'
 
@@ -20,11 +24,10 @@ import { useTranslation } from 'react-i18next'
 
 export default () => {
     //TODO these shouldn't be queried. Events and organizations should be in the state
-    const [activeEvents] = useActiveEvents({ limit: 3 })
-    const [pastEvents] = usePastEvents({ limit: 3 })
+    const [activeButNotHidden] = useActiveButNotHidden({ limit: 3 })
+    const [pastEvents] = usePastEvents({ limit: 6 })
     const [organizations] = useAllOrganizations()
 
-    console.log('HELMET', Helmet.peek())
     const { t } = useTranslation()
     return (
         <PageWrapper
@@ -90,7 +93,7 @@ export default () => {
                     <CenteredContainer>
                         <EventsGrid
                             title={t('Upcoming_')}
-                            events={activeEvents}
+                            events={activeButNotHidden}
                             organizations={organizations}
                         />
                         <EventsGrid

--- a/frontend/src/pages/_organise/slug/edit/configuration/index.js
+++ b/frontend/src/pages/_organise/slug/edit/configuration/index.js
@@ -86,7 +86,7 @@ export default () => {
                     render={({ field, form }) => (
                         <FormControl
                             label="Event type"
-                            hint="Is this a physical or online event?"
+                            hint="Is this a physical, online or hidden event?"
                             error={form.errors[field.name]}
                             touched={form.touched[field.name]}
                         >

--- a/shared/constants/event-types.js
+++ b/shared/constants/event-types.js
@@ -7,6 +7,10 @@ const EventTypes = {
         id: 'online',
         label: 'Online event',
     },
+    hidden: {
+        id: 'hidden',
+        label: 'Hidden event',
+    },
 }
 
 module.exports = EventTypes


### PR DESCRIPTION
I found #62 quite fascinating so I took the chance to implement it.

This feature is implemented by:

- Adding a new 'event type' => hidden event
- New GraphQL query that only grabs the events that aren't hidden
- Uses this graphql query in the index page

I've tested this feature locally, and at least it works for me when using the link directly to the event, but there may be unexpected problems that should be considered. If I'm understanding correctly the activeEvents were used everywhere else, so this is basically only a frontpage feature.