### PR TITLE
Event landing page customization

### DIFF
--- a/backend/modules/event/graphql.js
+++ b/backend/modules/event/graphql.js
@@ -23,6 +23,7 @@ const {
     RegistrationSection,
     EventTag,
     RegistrationConfig,
+    EventTheme,
 } = require('../graphql-shared-types')
 
 const Organization = require('../organization/model')
@@ -159,6 +160,9 @@ const EventType = new GraphQLObjectType({
             },
             approved: {
                 type: GraphQLBoolean,
+            },
+            theme: {
+                type: EventTheme,
             },
             // Implement userprofile in graphql
             // TODO: Figure this stuff out

--- a/backend/modules/event/model.js
+++ b/backend/modules/event/model.js
@@ -16,6 +16,7 @@ const EventTagSchema = require('@hackjunction/shared/schemas/EventTag')
 const RegistrationConfigSchema = require('@hackjunction/shared/schemas/RegistrationConfig')
 const AddressSchema = require('@hackjunction/shared/schemas/Address')
 const WebhookSchema = require('@hackjunction/shared/schemas/Webhook')
+const EventThemeSchema = require('@hackjunction/shared/schemas/EventTheme')
 const allowPublishPlugin = require('../../common/plugins/allowPublish')
 const updateAllowedPlugin = require('../../common/plugins/updateAllowed')
 const uploadHelper = require('../upload/helper')
@@ -272,6 +273,7 @@ const EventSchema = new mongoose.Schema({
         type: Boolean,
         default: false,
     },
+    theme: { type: EventThemeSchema.mongoose, default: {} },
 })
 
 EventSchema.index(

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -4785,135 +4785,11 @@
             "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
             "dev": true
         },
-        "@stdlib/array": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/array"
-        },
-        "@stdlib/assert": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/assert"
-        },
-        "@stdlib/bench": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/bench"
-        },
-        "@stdlib/blas": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/blas"
-        },
-        "@stdlib/buffer": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/buffer"
-        },
-        "@stdlib/complex": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/complex"
-        },
-        "@stdlib/constants": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/constants"
-        },
-        "@stdlib/crypto": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/crypto"
-        },
-        "@stdlib/datasets": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/datasets"
-        },
-        "@stdlib/error": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/error"
-        },
-        "@stdlib/fastmath": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/fastmath"
-        },
-        "@stdlib/fs": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/fs"
-        },
-        "@stdlib/iter": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/iter"
-        },
-        "@stdlib/math": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/math"
-        },
-        "@stdlib/ml": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/ml"
-        },
-        "@stdlib/namespace": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/namespace"
-        },
-        "@stdlib/ndarray": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/ndarray"
-        },
-        "@stdlib/net": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/net"
-        },
-        "@stdlib/nlp": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/nlp"
-        },
-        "@stdlib/number": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/number"
-        },
-        "@stdlib/os": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/os"
-        },
-        "@stdlib/plot": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/plot"
-        },
-        "@stdlib/process": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/process"
-        },
-        "@stdlib/proxy": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/proxy"
-        },
-        "@stdlib/random": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/random"
-        },
-        "@stdlib/regexp": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/regexp"
-        },
-        "@stdlib/repl": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/repl"
-        },
-        "@stdlib/simulate": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/simulate"
-        },
-        "@stdlib/stats": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/stats"
-        },
         "@stdlib/stdlib": {
             "version": "0.0.91",
             "resolved": "https://registry.npmjs.org/@stdlib/stdlib/-/stdlib-0.0.91.tgz",
             "integrity": "sha512-7zGaX/QGeBtlQKqwwpxSWUhzYxKU7tZo2BfhPKQPMq+buLdYjc2H+jRprXSW5kX1OXqi0l1aIV84ACvD3isNFQ==",
             "requires": {
-                "@stdlib/array": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/array",
-                "@stdlib/assert": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/assert",
-                "@stdlib/bench": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/bench",
-                "@stdlib/blas": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/blas",
-                "@stdlib/buffer": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/buffer",
-                "@stdlib/complex": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/complex",
-                "@stdlib/constants": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/constants",
-                "@stdlib/crypto": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/crypto",
-                "@stdlib/datasets": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/datasets",
-                "@stdlib/error": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/error",
-                "@stdlib/fastmath": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/fastmath",
-                "@stdlib/fs": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/fs",
-                "@stdlib/iter": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/iter",
-                "@stdlib/math": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/math",
-                "@stdlib/ml": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/ml",
-                "@stdlib/namespace": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/namespace",
-                "@stdlib/ndarray": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/ndarray",
-                "@stdlib/net": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/net",
-                "@stdlib/nlp": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/nlp",
-                "@stdlib/number": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/number",
-                "@stdlib/os": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/os",
-                "@stdlib/plot": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/plot",
-                "@stdlib/process": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/process",
-                "@stdlib/proxy": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/proxy",
-                "@stdlib/random": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/random",
-                "@stdlib/regexp": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/regexp",
-                "@stdlib/repl": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/repl",
-                "@stdlib/simulate": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/simulate",
-                "@stdlib/stats": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/stats",
-                "@stdlib/streams": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/streams",
-                "@stdlib/strided": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/strided",
-                "@stdlib/string": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/string",
-                "@stdlib/symbol": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/symbol",
-                "@stdlib/time": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/time",
-                "@stdlib/tools": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/tools",
-                "@stdlib/types": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/types",
-                "@stdlib/utils": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/utils",
                 "acorn": "^7.0.0",
                 "acorn-loose": "^7.0.0",
                 "acorn-walk": "^7.0.0",
@@ -4942,30 +4818,6 @@
                     }
                 }
             }
-        },
-        "@stdlib/streams": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/streams"
-        },
-        "@stdlib/strided": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/strided"
-        },
-        "@stdlib/string": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/string"
-        },
-        "@stdlib/symbol": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/symbol"
-        },
-        "@stdlib/time": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/time"
-        },
-        "@stdlib/tools": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/tools"
-        },
-        "@stdlib/types": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/types"
-        },
-        "@stdlib/utils": {
-            "version": "file:node_modules/@stdlib/stdlib/lib/node_modules/@stdlib/utils"
         },
         "@szmarczak/http-timer": {
             "version": "1.1.2",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2768,6 +2768,11 @@
                 "@hapi/hoek": "^8.3.0"
             }
         },
+        "@icons/material": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+            "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
+        },
         "@jest/console": {
             "version": "24.9.0",
             "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -10765,6 +10770,11 @@
             "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
             "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
         },
+        "material-colors": {
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+            "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
+        },
         "math-expression-evaluator": {
             "version": "1.2.22",
             "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.22.tgz",
@@ -13644,6 +13654,20 @@
                 "use-memo-one": "^1.1.1"
             }
         },
+        "react-color": {
+            "version": "2.19.3",
+            "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.19.3.tgz",
+            "integrity": "sha512-LEeGE/ZzNLIsFWa1TMe8y5VYqr7bibneWmvJwm1pCn/eNmrabWDh659JSPn9BuaMpEfU83WTOJfnCcjDZwNQTA==",
+            "requires": {
+                "@icons/material": "^0.2.4",
+                "lodash": "^4.17.15",
+                "lodash-es": "^4.17.15",
+                "material-colors": "^1.2.1",
+                "prop-types": "^15.5.10",
+                "reactcss": "^1.2.0",
+                "tinycolor2": "^1.4.1"
+            }
+        },
         "react-countdown-now": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/react-countdown-now/-/react-countdown-now-2.1.2.tgz",
@@ -14457,6 +14481,14 @@
                 "dom-helpers": "^5.0.1",
                 "loose-envify": "^1.4.0",
                 "prop-types": "^15.6.2"
+            }
+        },
+        "reactcss": {
+            "version": "1.2.3",
+            "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+            "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+            "requires": {
+                "lodash": "^4.0.1"
             }
         },
         "read-pkg": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -38,6 +38,7 @@
         "qrcode.react": "^1.0.0",
         "react": "16.13.1",
         "react-beautiful-dnd": "^13.0.0",
+        "react-color": "^2.19.3",
         "react-countdown-now": "^2.1.2",
         "react-csv": "^2.0.3",
         "react-dom": "^16.13.1",

--- a/frontend/src/components/events/EventHeroImage/index.js
+++ b/frontend/src/components/events/EventHeroImage/index.js
@@ -28,7 +28,7 @@ const useStyles = makeStyles(theme => ({
         position: 'absolute',
         zIndex: 10,
         width: '100%',
-        paddingTop: theme.spacing(1),
+        paddingTop: theme.spacing(3),
     },
     logoWrapper: {
         position: 'absolute',
@@ -111,7 +111,7 @@ export default ({ event, title, subheading, onBack }) => {
                     </Box>
                 </FadeInWrapper>
             </Box> */}
-            <Container center wrapperClass={classes.backButtonWrapper}>
+            <Container wrapperClass={classes.backButtonWrapper}>
                 <Button
                     onClick={
                         typeof onBack === 'function'

--- a/frontend/src/components/generic/TimelineDot/index.js
+++ b/frontend/src/components/generic/TimelineDot/index.js
@@ -12,19 +12,19 @@ const useStyles = makeStyles(theme => ({
         justifyContent: 'center',
         margin: 0,
     },
-    dot: ({ active }) => ({
+    dot: ({ active, accentColor }) => ({
         width: '14px',
         height: '14px',
         borderStyle: 'solid',
         borderRadius: '50%',
-        borderColor: active ? '#19DDEA' : '#ccc',
-        backgroundColor: active ? 'transparent' : '#19DDEA',
+        borderColor: active ? accentColor || '#19DDEA' : '#ccc',
+        backgroundColor: active ? 'transparent' : accentColor || '#19DDEA',
         borderWidth: '1px',
     }),
 }))
 
-const TimelineDot = ({ active, completed }) => {
-    const classes = useStyles({ active })
+const TimelineDot = ({ active, completed, accentColor = undefined }) => {
+    const classes = useStyles({ active, accentColor })
     return (
         <div className={classes.root}>
             {completed ? (

--- a/frontend/src/components/inputs/Color/index.js
+++ b/frontend/src/components/inputs/Color/index.js
@@ -1,0 +1,80 @@
+import { makeStyles } from '@material-ui/core'
+import React, { useState } from 'react'
+import { BlockPicker } from 'react-color'
+
+const useStyles = makeStyles({
+    wrapper: {
+        display: 'flex',
+        alignItems: 'center',
+    },
+    previewCircle: {
+        height: 30,
+        width: 30,
+        border: '1px solid lightgray',
+        borderRadius: '50%',
+        background: props => props.backgroundColor,
+        display: 'inline-block',
+        marginRight: 8,
+        cursor: 'pointer',
+    },
+    previewText: {
+        padding: '8px 16px',
+        background: 'lightgray',
+        borderRadius: 6,
+        cursor: 'pointer',
+    },
+    picker: {
+        position: 'absolute',
+        zIndex: 2,
+
+        '& .block-picker': {
+            boxShadow: 'rgba(0, 0, 0, 0.3) 0px 0px 8px !important',
+        },
+    },
+    pageCover: {
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+    },
+})
+
+const ColorSelect = ({ onChange = color => {}, value = '' }) => {
+    const [isOpen, setIsOpen] = useState(false)
+    const classes = useStyles({ backgroundColor: value })
+
+    const togglePicker = () => {
+        setIsOpen(!isOpen)
+    }
+
+    const onColorChange = color => {
+        onChange(color.hex)
+        togglePicker()
+    }
+
+    return (
+        <div>
+            <div className={classes.wrapper}>
+                <span
+                    className={classes.previewCircle}
+                    onClick={togglePicker}
+                />
+                <span className={classes.previewText} onClick={togglePicker}>
+                    {value}
+                </span>
+            </div>
+            {isOpen && (
+                <div className={classes.picker}>
+                    <div className={classes.pageCover} onClick={togglePicker} />
+                    <BlockPicker
+                        color={value}
+                        onChangeComplete={onColorChange}
+                    />
+                </div>
+            )}
+        </div>
+    )
+}
+
+export default ColorSelect

--- a/frontend/src/components/inputs/Color/index.js
+++ b/frontend/src/components/inputs/Color/index.js
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core'
 import React, { useState } from 'react'
-import { BlockPicker } from 'react-color'
+import { CompactPicker } from 'react-color'
 
 const useStyles = makeStyles({
     wrapper: {
@@ -25,9 +25,9 @@ const useStyles = makeStyles({
     },
     picker: {
         position: 'absolute',
-        zIndex: 2,
+        zIndex: 501,
 
-        '& .block-picker': {
+        '& .compact-picker': {
             boxShadow: 'rgba(0, 0, 0, 0.3) 0px 0px 8px !important',
         },
     },
@@ -67,7 +67,7 @@ const ColorSelect = ({ onChange = color => {}, value = '' }) => {
             {isOpen && (
                 <div className={classes.picker}>
                     <div className={classes.pageCover} onClick={togglePicker} />
-                    <BlockPicker
+                    <CompactPicker
                         color={value}
                         onChangeComplete={onColorChange}
                     />

--- a/frontend/src/pages/_events/slug/context.js
+++ b/frontend/src/pages/_events/slug/context.js
@@ -54,6 +54,17 @@ const eventQuery = gql`
             frontPagePriority
             approved
             eventTerms
+            theme {
+                headerBackgroundColor
+                headerTextColor
+                bodyBackgroundColor
+                detailsBackgroundColor
+                detailsTextColor
+                sidebarBackgroundColor
+                sidebarTextColor
+                accentColor
+                linkColor
+            }
             _eventStatus
             _eventTimeFormatted
             _eventLocationFormatted

--- a/frontend/src/pages/_events/slug/default/EventInformation/index.js
+++ b/frontend/src/pages/_events/slug/default/EventInformation/index.js
@@ -35,7 +35,7 @@ const EventInformation = ({ event, registration }) => {
                 <Typography variant="body1" className={classes.date}>
                     {event._eventLocationFormatted}
                 </Typography>
-                <Box>
+                <Box pb={2}>
                     <EventButtons event={event} registration={registration} />
                 </Box>
             </Grid>

--- a/frontend/src/pages/_events/slug/default/EventTimeline/index.js
+++ b/frontend/src/pages/_events/slug/default/EventTimeline/index.js
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react'
-
+import PropTypes from 'prop-types'
 import { makeStyles, withStyles } from '@material-ui/core/styles'
 import {
     Stepper,
@@ -24,6 +24,7 @@ const useStyles = makeStyles(theme => ({
         marginTop: '-9px',
         marginLeft: '6px',
         textTransform: 'uppercase',
+        color: props => props.textColor,
     },
     date: {
         fontWeight: 'bold',
@@ -32,10 +33,17 @@ const useStyles = makeStyles(theme => ({
     },
     label: {
         marginTop: '-9px',
+        '& .MuiStepLabel-label': {
+            color: props => props.textColor,
+            opacity: 0.54,
+        },
+        '& .MuiStepLabel-active': {
+            opacity: 0.87,
+        },
     },
 }))
 
-const ColorlibConnector = withStyles({
+const colorLibStyle = props => ({
     root: {
         marginLeft: '6px',
         paddingBottom: 0,
@@ -51,20 +59,27 @@ const ColorlibConnector = withStyles({
         },
     },
     line: {
-        borderColor: props => props.accentColor || '#19DDEA',
+        borderColor: props => props.accent || '#19DDEA',
 
         borderRadius: 1,
     },
     lineVertical: {
-        borderColor: props => props.accentColor || '#19DDEA',
+        borderColor: props => props.accent || '#19DDEA',
         padding: 0,
 
         borderRadius: 1,
     },
-})(StepConnector)
+})
 
-const EventTimeline = ({ event, accentColor = undefined }) => {
-    const classes = useStyles({ accentColor })
+const ColorlibConnector = withStyles(colorLibStyle())(StepConnector)
+
+ColorlibConnector.propTypes = {
+    ...ColorlibConnector.propTypes,
+    accent: PropTypes.string,
+}
+
+const EventTimeline = ({ event, textColor, accentColor = undefined }) => {
+    const classes = useStyles({ accentColor, textColor })
     const timelineItems = useMemo(() => {
         const items = [
             {
@@ -109,7 +124,7 @@ const EventTimeline = ({ event, accentColor = undefined }) => {
             className={classes.root}
             activeStep={0}
             orientation="vertical"
-            connector={<ColorlibConnector accentColor={accentColor} />}
+            connector={<ColorlibConnector accent={accentColor} />}
         >
             {timelineItems.map(item => (
                 <Step

--- a/frontend/src/pages/_events/slug/default/EventTimeline/index.js
+++ b/frontend/src/pages/_events/slug/default/EventTimeline/index.js
@@ -19,7 +19,7 @@ const useStyles = makeStyles(theme => ({
         background: 'transparent',
     },
     borderContent: {
-        borderColor: '#19DDEA',
+        borderColor: props => props.accentColor || '#19DDEA',
         paddingTop: '8px',
         marginTop: '-9px',
         marginLeft: '6px',
@@ -51,20 +51,20 @@ const ColorlibConnector = withStyles({
         },
     },
     line: {
-        borderColor: '#19DDEA',
+        borderColor: props => props.accentColor || '#19DDEA',
 
         borderRadius: 1,
     },
     lineVertical: {
-        borderColor: '#19DDEA',
+        borderColor: props => props.accentColor || '#19DDEA',
         padding: 0,
 
         borderRadius: 1,
     },
 })(StepConnector)
 
-const EventTimeline = ({ event }) => {
-    const classes = useStyles()
+const EventTimeline = ({ event, accentColor = undefined }) => {
+    const classes = useStyles({ accentColor })
     const timelineItems = useMemo(() => {
         const items = [
             {
@@ -109,7 +109,7 @@ const EventTimeline = ({ event }) => {
             className={classes.root}
             activeStep={0}
             orientation="vertical"
-            connector={<ColorlibConnector />}
+            connector={<ColorlibConnector accentColor={accentColor} />}
         >
             {timelineItems.map(item => (
                 <Step
@@ -119,7 +119,9 @@ const EventTimeline = ({ event }) => {
                     expanded
                 >
                     <StepLabel
-                        StepIconComponent={TimelineDot}
+                        StepIconComponent={props => (
+                            <TimelineDot {...props} accentColor={accentColor} />
+                        )}
                         className={classes.label}
                     >
                         <Typography variant="button" className={classes.date}>

--- a/frontend/src/pages/_events/slug/default/index.js
+++ b/frontend/src/pages/_events/slug/default/index.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles({
         background: props => props.headerBackgroundColor,
         color: props => props.headerTextColor,
 
-        button: {
+        '& button': {
             color: props => props.accentColor,
         },
     },
@@ -39,10 +39,13 @@ const useStyles = makeStyles({
     details: {
         background: props => props.detailsBackgroundColor,
         color: props => props.detailsTextColor,
+
+        '& *': {
+            color: props => props.detailsTextColor,
+        },
     },
     sidebar: {
         background: props => props.sidebarBackgroundColor,
-        color: props => props.sidebarTextColor,
     },
 })
 
@@ -158,6 +161,9 @@ export default () => {
                                             event={event}
                                             accentColor={
                                                 event.theme.accentColor
+                                            }
+                                            textColor={
+                                                event.theme.sidebarTextColor
                                             }
                                         />
                                     </StaggeredListItem>

--- a/frontend/src/pages/_events/slug/default/index.js
+++ b/frontend/src/pages/_events/slug/default/index.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useContext, useState } from 'react'
 
-import { Grid, Box, Typography } from '@material-ui/core'
+import { Grid, Box, Typography, makeStyles } from '@material-ui/core'
 import { useDispatch, useSelector } from 'react-redux'
 import { push } from 'connected-react-router'
 import moment from 'moment'
@@ -21,9 +21,35 @@ import { Helmet } from 'react-helmet'
 import EventDetailContext from '../context'
 import BannerService from 'services/banner'
 
+const useStyles = makeStyles({
+    header: {
+        background: props => props.headerBackgroundColor,
+        color: props => props.headerTextColor,
+
+        button: {
+            color: props => props.accentColor,
+        },
+    },
+    body: {
+        background: props => props.bodyBackgroundColor,
+        '& a>p': {
+            color: props => props.linkColor,
+        },
+    },
+    details: {
+        background: props => props.detailsBackgroundColor,
+        color: props => props.detailsTextColor,
+    },
+    sidebar: {
+        background: props => props.sidebarBackgroundColor,
+        color: props => props.sidebarTextColor,
+    },
+})
+
 export default () => {
     const dispatch = useDispatch()
     const { slug, event, registration } = useContext(EventDetailContext)
+    const classes = useStyles(event.theme)
 
     const keywords = event.name.split(' ').join(', ')
     console.log('KEYWORDS', keywords)
@@ -81,42 +107,76 @@ export default () => {
                 <meta name="twitter:image" content={coverImage()} />
             </Helmet>
             <EventHeroImage event={event} onBack={() => dispatch(push('/'))} />
-            <FadeInWrapper>
-                <Container center>
-                    <StaggeredList>
-                        <Grid container spacing={5} wrap="wrap-reverse">
-                            <Grid item xs={12} md={4}>
-                                <Box mt={3} />
-                                <StaggeredListItem>
-                                    <Box mt={3} />
-                                    <EventTimeline event={event} />
-                                </StaggeredListItem>
-                            </Grid>
-                            <Grid item xs={12} md={8}>
-                                <Box mt={3} />
-                                <StaggeredListItem>
-                                    <Markdown source={event?.description} />
-                                </StaggeredListItem>
-                            </Grid>
-                            <Grid item xs={12} md={4}>
-                                <Box mt={3} />
-                            </Grid>
-                            <Grid item xs={12} md={8}>
-                                <Box mt={3} />
 
-                                <Typography variant="h2">
-                                    {event.name}
-                                </Typography>
-                                <Grid container justify="space-between">
-                                    <EventInformation
-                                        registration={registration}
-                                        event={event}
-                                    />
+            <FadeInWrapper>
+                <StaggeredList>
+                    <Box className={classes.header}>
+                        <Container>
+                            <Grid container spacing={5}>
+                                <Grid
+                                    item
+                                    xs={12}
+                                    md={4}
+                                    className={classes.header}
+                                >
+                                    <Box mt={3} />
+                                </Grid>
+                                <Grid
+                                    item
+                                    xs={12}
+                                    md={8}
+                                    className={classes.header}
+                                >
+                                    <Box mt={3} />
+
+                                    <Typography variant="h2">
+                                        {event.name}
+                                    </Typography>
+                                    <Grid container justify="space-between">
+                                        <EventInformation
+                                            registration={registration}
+                                            event={event}
+                                        />
+                                    </Grid>
                                 </Grid>
                             </Grid>
-                        </Grid>
-                    </StaggeredList>
-                </Container>
+                        </Container>
+                    </Box>
+                    <Box className={classes.body}>
+                        <Container>
+                            <Grid container spacing={5} wrap="wrap-reverse">
+                                <Grid
+                                    item
+                                    xs={12}
+                                    md={4}
+                                    className={classes.sidebar}
+                                >
+                                    <Box mt={3} />
+                                    <StaggeredListItem>
+                                        <Box mt={3} />
+                                        <EventTimeline
+                                            event={event}
+                                            accentColor={
+                                                event.theme.accentColor
+                                            }
+                                        />
+                                    </StaggeredListItem>
+                                </Grid>
+                                <Grid
+                                    item
+                                    xs={12}
+                                    md={8}
+                                    className={classes.details}
+                                >
+                                    <Box mt={3} />
+                                    <StaggeredListItem>
+                                        <Markdown source={event?.description} />
+                                    </StaggeredListItem>
+                                </Grid>
+                            </Grid>
+                        </Container>
+                    </Box>
+                </StaggeredList>
             </FadeInWrapper>
             <BannerCarousel />
         </>

--- a/frontend/src/pages/_organise/slug/edit/default/const.js
+++ b/frontend/src/pages/_organise/slug/edit/default/const.js
@@ -1,0 +1,11 @@
+export const defaultEventStyles = {
+    headerBackgroundColor: '#ffffff',
+    headerTextColor: '#000000',
+    bodyBackgroundColor: '#ffffff',
+    detailsBackgroundColor: '#ffffff',
+    detailsTextColor: '#000000',
+    sidebarBackgroundColor: '#ffffff',
+    sidebarTextColor: '#000000',
+    accentColor: '#73f9ec',
+    linkColor: '#52d7af',
+}

--- a/frontend/src/pages/_organise/slug/edit/default/index.js
+++ b/frontend/src/pages/_organise/slug/edit/default/index.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react'
 
-import { useSelector } from 'react-redux'
-import { Grid, Box } from '@material-ui/core'
+import { useDispatch, useSelector } from 'react-redux'
+import { Grid, Box, Typography } from '@material-ui/core'
 import { FastField } from 'formik'
 
 import MarkdownInput from 'components/inputs/MarkdownInput'
@@ -12,10 +12,63 @@ import Select from 'components/inputs/Select'
 
 import * as OrganiserSelectors from 'redux/organiser/selectors'
 import { useAllOrganizations } from 'graphql/queries/organization'
+import ColorSelect from 'components/inputs/Color'
+import Button from 'components/generic/Button'
+import { push } from 'connected-react-router'
+import { defaultEventStyles } from './const'
 
+const themeFields = [
+    {
+        field: 'headerBackgroundColor',
+        label: 'Header background',
+        hint: 'Background color of the header section',
+    },
+    {
+        field: 'headerTextColor',
+        label: 'Header text',
+        hint: 'Text color of the header section',
+    },
+    {
+        field: 'bodyBackgroundColor',
+        label: 'Page background',
+        hint:
+            'Background color of the main body of the page (visible on wide screens)',
+    },
+    {
+        field: 'detailsBackgroundColor',
+        label: 'Event details background',
+        hint: 'Background color of the event details section',
+    },
+    {
+        field: 'detailsTextColor',
+        label: 'Event details text',
+        hint: 'Text color of the event details section',
+    },
+    {
+        field: 'sidebarBackgroundColor',
+        label: 'Sidebar background',
+        hint: 'Background color of the sidebar section',
+    },
+    {
+        field: 'sidebarTextColor',
+        label: 'Sidebar text',
+        hint: 'Text color of the sidebar section',
+    },
+    {
+        field: 'accentColor',
+        label: 'Accent color',
+        hint: 'Accent color used on buttons and timeline',
+    },
+    {
+        field: 'linkColor',
+        label: 'Link color',
+        hint: 'Text color of links in the event details',
+    },
+]
 export default () => {
     const event = useSelector(OrganiserSelectors.event)
     const [organizations] = useAllOrganizations()
+    const dispatch = useDispatch()
 
     return (
         <Grid container spacing={3}>
@@ -258,6 +311,70 @@ export default () => {
                         </FormControl>
                     )}
                 />
+            </Grid>
+            <Grid item xs={12}>
+                <Typography variant="h5">Event page customization</Typography>
+            </Grid>
+            <Grid item xs={12}>
+                <Grid container spacing={5}>
+                    {themeFields.map(themeField => (
+                        <Grid
+                            item
+                            xs={12}
+                            md={6}
+                            lg={4}
+                            key={themeField.field}
+                            id={themeField.field}
+                        >
+                            <FastField
+                                name={`theme.${themeField.field}`}
+                                render={({ field, form }) => (
+                                    <FormControl
+                                        label={themeField.label}
+                                        hint={themeField.hint}
+                                        error={form.errors[field.name]}
+                                        touched={form.touched[field.name]}
+                                    >
+                                        <ColorSelect
+                                            value={field.value}
+                                            onChange={value =>
+                                                form.setFieldValue(
+                                                    field.name,
+                                                    value,
+                                                )
+                                            }
+                                        />
+                                    </FormControl>
+                                )}
+                            />
+                        </Grid>
+                    ))}
+                    <Grid item xs={12}>
+                        <Button
+                            variant="contained"
+                            onClick={() =>
+                                dispatch(push('/events/' + event.slug))
+                            }
+                        >
+                            Preview
+                        </Button>
+                        <FastField
+                            name="theme"
+                            render={({ form }) => (
+                                <Button
+                                    onClick={() =>
+                                        form.setFieldValue(
+                                            'theme',
+                                            defaultEventStyles,
+                                        )
+                                    }
+                                >
+                                    Reset defaults
+                                </Button>
+                            )}
+                        />
+                    </Grid>
+                </Grid>
             </Grid>
         </Grid>
     )

--- a/shared/schemas/EventTheme.js
+++ b/shared/schemas/EventTheme.js
@@ -1,0 +1,79 @@
+const mongoose = require('mongoose')
+const { GraphQLObjectType, GraphQLString, GraphQLNonNull } = require('graphql')
+
+const EventThemeSchema = new mongoose.Schema({
+    headerBackgroundColor: {
+        type: String,
+        default: '#ffffff',
+    },
+    headerTextColor: {
+        type: String,
+        default: '#000000',
+    },
+    bodyBackgroundColor: {
+        type: String,
+        default: '#ffffff',
+    },
+    detailsBackgroundColor: {
+        type: String,
+        default: '#ffffff',
+    },
+    detailsTextColor: {
+        type: String,
+        default: '#000000',
+    },
+    sidebarBackgroundColor: {
+        type: String,
+        default: '#ffffff',
+    },
+    sidebarTextColor: {
+        type: String,
+        default: '#000000',
+    },
+    accentColor: {
+        type: String,
+        default: '#73f9ec',
+    },
+    linkColor: {
+        type: String,
+        default: '#52d7af',
+    },
+})
+
+const EventThemeType = new GraphQLObjectType({
+    name: 'EventTheme',
+    fields: {
+        headerBackgroundColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        headerTextColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        bodyBackgroundColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        detailsBackgroundColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        detailsTextColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        sidebarBackgroundColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        sidebarTextColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        accentColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        linkColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+    },
+})
+
+module.exports = {
+    mongoose: EventThemeSchema,
+    graphql: EventThemeType,
+}

--- a/shared/schemas/index.js
+++ b/shared/schemas/index.js
@@ -24,6 +24,7 @@ const UserDetailsConfig = require('./UserDetailsConfig')
 const UserDetailsConfigItem = require('./UserDetailsConfigItem')
 const UserProfileFields = require('./UserProfileFields')
 const Webhook = require('./Webhook')
+const EventTheme = require('./EventTheme')
 // const GraphQLSchema = makeExecutableSchema
 
 const SharedSchema = new GraphQLSchema({
@@ -52,6 +53,7 @@ const SharedSchema = new GraphQLSchema({
         UserDetailsConfigItem.graphql,
         UserProfileFields.graphql,
         Webhook.graphql,
+        EventTheme.graphql,
     ],
 })
 


### PR DESCRIPTION
This PR adds the ability to customize the color scheme of event landing pages. The goal here is to be able to create unique landing pages so participants arrive at an event landing page that is more in-line with the branding of the hackathon. 

This PR touches on issues #158 #154 and #63

The solution proposed here adds a `theme` field to the `Event` model and uses the values in that object to override the styles of the landing page.

Here are a couple of screenshots of how this might look like:
![image](https://user-images.githubusercontent.com/17903881/103364995-5d551c80-4abf-11eb-9613-aa1028226201.png)
![image](https://user-images.githubusercontent.com/17903881/103365014-6514c100-4abf-11eb-80b7-cb1732c114d2.png)

