### PR TITLE
show winners tab for organizers who haven't regiresterd

### DIFF
--- a/backend/modules/event/routes.js
+++ b/backend/modules/event/routes.js
@@ -14,7 +14,7 @@ const {
 const {
     isEventOwner,
     isEventOrganiser,
-    hasRegisteredToEvent,
+    getEventFromParams,
 } = require('../../common/middleware/events')
 const { hasToken } = require('../../common/middleware/token')
 
@@ -207,7 +207,7 @@ router
 
 router
     .route('/:slug/winners')
-    .get(hasToken, hasRegisteredToEvent, getWinnerProjects)
+    .get(hasToken, getEventFromParams, getWinnerProjects)
     .patch(
         hasToken,
         hasPermission(Auth.Permissions.MANAGE_EVENT),
@@ -217,7 +217,7 @@ router
 
 router
     .route('/:slug/finalist')
-    .get(hasToken, hasRegisteredToEvent, getFinalists)
+    .get(hasToken, getEventFromParams, getFinalists)
     .patch(
         hasToken,
         hasPermission(Auth.Permissions.MANAGE_EVENT),


### PR DESCRIPTION
Previosly winners and finalists were visible only for registered users in api. This fixes makes them public.