### PR TITLE
Fix sidebar on desktop

### DIFF
--- a/frontend/src/components/layouts/SidebarLayout/index.js
+++ b/frontend/src/components/layouts/SidebarLayout/index.js
@@ -134,7 +134,7 @@ export default React.memo(
         const safeIndex = activeIndex === -1 ? 0 : activeIndex
 
         const [mobileOpen, setMobileOpen] = React.useState(false)
-        const [desktopOpen, setDesktopOpen] = React.useState(false)
+        const [desktopOpen, setDesktopOpen] = React.useState(true)
 
         const classes = useStyles({ desktopOpen })
 


### PR DESCRIPTION
This is quite an easy suggestion for #441 , instead of remodelling it at all, let's just change the default value on the page from false -> true. This gives user the opportunity to close the sidebar, but it's still visible when they visit the page?

Thoughts?