### PR TITLE
Improve event page button design

### DIFF
--- a/frontend/src/components/generic/Button/index.js
+++ b/frontend/src/components/generic/Button/index.js
@@ -61,7 +61,6 @@ const variantStyles = (theme, props) => {
         case 'applicationsClosed': {
             return {
                 color: color.main,
-                padding: 0,
                 margin: '25px 0 0 0',
                 textTransform: 'uppercase',
                 fontSize: '18px',

--- a/frontend/src/pages/_events/slug/default/EventTimeline/index.js
+++ b/frontend/src/pages/_events/slug/default/EventTimeline/index.js
@@ -50,12 +50,12 @@ const colorLibStyle = props => ({
     },
     active: {
         '& $line': {
-            borderColor: '#784af4',
+            borderColor: props => props.accent || '#784af4',
         },
     },
     completed: {
         '& $line': {
-            borderColor: '#784af4',
+            borderColor: props => props.accent || '#784af4',
         },
     },
     line: {

--- a/frontend/src/pages/_events/slug/default/index.js
+++ b/frontend/src/pages/_events/slug/default/index.js
@@ -17,14 +17,30 @@ import FadeInWrapper from 'components/animated/FadeInWrapper'
 import Container from 'components/generic/Container'
 import { Helmet } from 'react-helmet'
 import EventDetailContext from '../context'
+import EventButtons from './EventButtons'
 
 const useStyles = makeStyles({
     header: {
         background: props => props.headerBackgroundColor,
         color: props => props.headerTextColor,
 
+        '& button:not(disabled)': {
+            color: props => props.headerBackgroundColor,
+            background: props => props.accentColor,
+
+            '&:hover': {
+                background: props => props.linkColor,
+            },
+        },
+    },
+    cta: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '3rem 2rem',
+        margin: '20px 0 0 0',
         '& button': {
-            color: props => props.accentColor,
+            margin: 0,
         },
     },
     body: {
@@ -178,6 +194,12 @@ export default () => {
                                 </Grid>
                             </Grid>
                         </Container>
+                    </Box>
+                    <Box className={`${classes.header} ${classes.cta}`}>
+                        <EventButtons
+                            event={event}
+                            registration={registration}
+                        />
                     </Box>
                 </StaggeredList>
             </FadeInWrapper>

--- a/frontend/src/pages/_pricing/index.js
+++ b/frontend/src/pages/_pricing/index.js
@@ -38,7 +38,7 @@ export default () => {
     const { t } = useTranslation()
     const body1 = [
         'Event registration and organization through platform.',
-        'For non - profit organizations.'
+        'For non - profit organizations.',
     ]
     const body2 = [
         'Event registration and organization through platform',


### PR DESCRIPTION
This change improves the design of the CTA button on the event detail pages. The current issue is that these buttons look like links/text and they are not discoverable. 

With these changes, they'll look more like buttons and they'll be customizable via the event theme settings. Further, this adds an extra CTA section below the event details text, so the button is shown twice on the page to increase CTR.

Button now has a background and padding:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/17903881/173193059-60c59451-1802-40fd-ab24-cf50e74a538d.png">

Button re-appears on the bottom of the page:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/17903881/173193070-d2ad6417-c82b-444b-9cfd-979759c57d37.png">
