### PR TITLE
Cover photo dimensions should be 16/9

### DIFF
--- a/frontend/src/components/events/EventCard/index.js
+++ b/frontend/src/components/events/EventCard/index.js
@@ -16,7 +16,10 @@ const useStyles = makeStyles(theme => ({
         flex: 1,
     },
     top: {
-        height: '148px',
+        height: '200px',
+        maxWidth: 'min(100%, 400px)',
+        aspectRatio: '16/9',
+        margin: '0 auto',
         position: 'relative',
         display: 'flex',
         justifyContent: 'flex-end',

--- a/frontend/src/components/events/EventHeroImage/index.js
+++ b/frontend/src/components/events/EventHeroImage/index.js
@@ -2,7 +2,7 @@ import React from 'react'
 
 import { useDispatch } from 'react-redux'
 import { goBack } from 'connected-react-router'
-import { Box } from '@material-ui/core'
+import { Box, Grid } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 
 import ArrowBackIosIcon from '@material-ui/icons/ArrowBackIos'
@@ -12,22 +12,31 @@ import Container from 'components/generic/Container'
 
 const useStyles = makeStyles(theme => ({
     wrapper: {
+        position: 'relative',
+        background: props => props.backgroundColor ?? undefined,
+        paddingTop: theme.spacing(2),
+    },
+    imageContainer: {
         display: 'flex',
-        overflow: 'hidden',
     },
     image: {
         zIndex: 1,
         top: 0,
         left: 0,
-        width: '100%',
-        height: '465px',
         objectFit: 'cover',
+        aspectRatio: '16/9',
+        maxHeight: 500,
+        borderRadius: 6,
+        margin: '0 auto',
+        boxShadow: '2px 7px 15px rgba(0, 0, 0, 0.12)',
     },
     backButtonWrapper: {
         position: 'absolute',
         zIndex: 10,
         width: 'auto',
         paddingTop: theme.spacing(3),
+        top: 0,
+        left: 0,
     },
     buttonInner: {
         color: 'black',
@@ -67,20 +76,40 @@ const useStyles = makeStyles(theme => ({
     },
 }))
 
-export default ({ event, title = '', subheading = '', onBack }) => {
+export default ({
+    event,
+    title = '',
+    subheading = '',
+    onBack,
+    backgroundColor,
+    alignRight,
+}) => {
     const dispatch = useDispatch()
-    const classes = useStyles()
+    const classes = useStyles({ backgroundColor })
     return (
         <Box className={classes.wrapper}>
-            <Image
-                className={classes.image}
-                publicId={event?.coverImage?.publicId}
-                defaultImage={require('assets/images/default_cover_image.png')}
-                transformation={{
-                    width: 1440,
-                    height: 465,
-                }}
-            />
+            <Container>
+                <Grid container>
+                    {alignRight && <Grid item xs={12} md={4} />}
+                    <Grid
+                        item
+                        xs={12}
+                        md={alignRight ? 8 : 12}
+                        className={classes.imageContainer}
+                    >
+                        <Image
+                            className={classes.image}
+                            publicId={event?.coverImage?.publicId}
+                            defaultImage={require('assets/images/default_cover_image.png')}
+                            transformation={{
+                                width: 1920,
+                                height: 1080,
+                            }}
+                        />
+                    </Grid>
+                </Grid>
+            </Container>
+
             {/* <Box className={classes.logoWrapper}>
                 <FadeInWrapper enterDelay={0.3} verticalOffset={50}>
                     <Box

--- a/frontend/src/pages/_events/slug/default/index.js
+++ b/frontend/src/pages/_events/slug/default/index.js
@@ -106,8 +106,12 @@ export default () => {
                 <meta property="og:image" content={coverImage()} />
                 <meta name="twitter:image" content={coverImage()} />
             </Helmet>
-            <EventHeroImage event={event} onBack={() => dispatch(push('/'))} />
-
+            <EventHeroImage
+                event={event}
+                onBack={() => dispatch(push('/'))}
+                alignRight
+                backgroundColor={event.theme.headerBackgroundColor}
+            />
             <FadeInWrapper>
                 <StaggeredList>
                     <Box className={classes.header}>

--- a/frontend/src/pages/_pricing/index.js
+++ b/frontend/src/pages/_pricing/index.js
@@ -38,7 +38,7 @@ export default () => {
     const { t } = useTranslation()
     const body1 = [
         'Event registration and organization through platform.',
-        'For non - profit organizations.'
+        'For non - profit organizations.',
     ]
     const body2 = [
         'Event registration and organization through platform',


### PR DESCRIPTION
This PR improves the image ratio settings and design of the event cover photo. The current issue is that even though the dashboard recommends admins to upload a 1920x1080 picture, this image is reformatted into multiple aspect ratios and is used as a full width cover photo, resulting in bad looking event pages and non-visible text.

This PR changes the layout of the event detail page so that the cover photo can maintain a fixed aspect ratio. Further, it also updates the EventCard so it also respects this ratio if possible. 

Event detail page with card-like cover photo (all corners visible):
<img width="1191" alt="Screenshot 2022-06-12 at 10 39 37" src="https://user-images.githubusercontent.com/17903881/173225110-ee4f521d-4b5a-4590-b789-99c52b961267.png">

Scales to full width on mobile:
<img width="391" alt="Screenshot 2022-06-12 at 10 40 27" src="https://user-images.githubusercontent.com/17903881/173225126-6162034f-3e73-4314-8fc3-25ee0c02cca7.png">

Corners visible on EventCard:
<img width="1190" alt="Screenshot 2022-06-12 at 10 39 45" src="https://user-images.githubusercontent.com/17903881/173225151-1f9dd4d3-2f32-467f-bd8b-b5c3ef1e68a5.png">

Cover photo is center aligned on project gallery page:
<img width="1440" alt="Screenshot 2022-06-12 at 10 42 06" src="https://user-images.githubusercontent.com/17903881/173225161-ad465762-42e2-4f5c-b0eb-a5d59bdcf4af.png">


Works nicely with a customized event page:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/17903881/173225222-7ecb12a7-a4b7-4d9d-9da5-7ddca4162121.png">
