### PR TITLE
Improve organiser invitation drawer

### DIFF
--- a/frontend/src/pages/_organise/slug/manage/AddOrganiserDrawer.js
+++ b/frontend/src/pages/_organise/slug/manage/AddOrganiserDrawer.js
@@ -10,6 +10,8 @@ import {
     ListItem,
     ListItemSecondaryAction,
     IconButton,
+    ListItemAvatar,
+    Avatar,
 } from '@material-ui/core'
 import AddIcon from '@material-ui/icons/Add'
 
@@ -57,7 +59,7 @@ export default ({ isOpen, onClose, onAdded, organisers, slug }) => {
                     Search for users
                 </Typography>
                 <TextInput
-                    placeholder="Name / email"
+                    placeholder="Search by first name, last name or e-mail address"
                     value={searchValue}
                     onChange={setSearchValue}
                 />
@@ -74,9 +76,37 @@ export default ({ isOpen, onClose, onAdded, organisers, slug }) => {
                 <List>
                     {results.map(user => (
                         <ListItem key={user.userId}>
+                            <ListItemAvatar>
+                                <Avatar
+                                    alt={'User avatar image'}
+                                    src={user ? user.avatar : ''}
+                                />
+                            </ListItemAvatar>
+
                             <ListItemText
                                 primary={`${user.firstName} ${user.lastName}`}
-                                secondary={user.userId}
+                                secondary={
+                                    <React.Fragment>
+                                        <Typography
+                                            component="p"
+                                            variant="body2"
+                                        >
+                                            E-mail:{' '}
+                                            <strong>{user.email}</strong>
+                                        </Typography>
+                                        <Typography
+                                            component="p"
+                                            variant="body2"
+                                        >
+                                            Account created:{' '}
+                                            <strong>
+                                                {new Date(
+                                                    user.createdAt,
+                                                ).toLocaleString()}
+                                            </strong>
+                                        </Typography>
+                                    </React.Fragment>
+                                }
                             />
                             {organisers.indexOf(user.userId) === -1 ? (
                                 <ListItemSecondaryAction>

--- a/frontend/src/pages/_pricing/index.js
+++ b/frontend/src/pages/_pricing/index.js
@@ -38,7 +38,7 @@ export default () => {
     const { t } = useTranslation()
     const body1 = [
         'Event registration and organization through platform.',
-        'For non - profit organizations.'
+        'For non - profit organizations.',
     ]
     const body2 = [
         'Event registration and organization through platform',


### PR DESCRIPTION
Small changes to the organiser invitation dialog so it's clearer how/what can be searched and the results are easier to distinguish. It's currently difficult to select the correct person to invite because multiple people could have the same name and the userID does not help non-technical users identify the correct user to add as an organiser.

Improve placeholder text:
<img width="506" alt="Screenshot 2022-06-12 at 14 26 03" src="https://user-images.githubusercontent.com/17903881/173233304-8ce3587d-bd9d-4561-a9eb-e09861cc15be.png">

Improve result granularity:
<img width="555" alt="Screenshot 2022-06-12 at 14 25 43" src="https://user-images.githubusercontent.com/17903881/173233312-b14ac1a5-255e-42c4-a427-db22f65eb0e3.png">


