### PR TITLE
Add new tab for finalist selection

### DIFF
--- a/backend/modules/event/controller.js
+++ b/backend/modules/event/controller.js
@@ -123,6 +123,14 @@ controller.updateFinalists = (eventId, finalist) => {
     })
 }
 
+controller.batchUpdateFinalists = (eventId, finalists) => {
+    console.log(eventId, finalists)
+    return Event.findById(eventId).then(event => {
+        event.finalists = finalists || []
+        return event.save()
+    })
+}
+
 controller.generateTrackPlacementAchievements = async event => {
     // If the event is not using tracks, get outta here
     if (!event.tracksEnabled) {

--- a/backend/modules/event/routes.js
+++ b/backend/modules/event/routes.js
@@ -119,6 +119,14 @@ const updateFinalists = asyncHandler(async (req, res) => {
     return res.status(200).json(event)
 })
 
+const batchUpdateFinalists = asyncHandler(async (req, res) => {
+    const event = await EventController.batchUpdateFinalists(
+        req.event._id,
+        req.body.projectIds,
+    )
+    return res.status(200).json(event)
+})
+
 const getFinalists = asyncHandler(async (req, res) => {
     const projects = await mongoose
         .model('Project')
@@ -223,6 +231,16 @@ router
         hasPermission(Auth.Permissions.MANAGE_EVENT),
         isEventOrganiser,
         updateFinalists,
+    )
+
+router
+    .route('/:slug/finalist/batch')
+    .get(hasToken, getEventFromParams, getFinalists)
+    .patch(
+        hasToken,
+        hasPermission(Auth.Permissions.MANAGE_EVENT),
+        isEventOrganiser,
+        batchUpdateFinalists,
     )
 
 /** Get organisers for single event */

--- a/frontend/src/pages/_organise/slug/edit/configuration/index.js
+++ b/frontend/src/pages/_organise/slug/edit/configuration/index.js
@@ -328,7 +328,14 @@ export default () => {
                     render={({ field, form }) => (
                         <FormControl
                             label="Overall winner method"
-                            hint="Which method should be used to determine the overall winner?"
+                            hint={`Which method should be used to determine the overall winner?
+
+*Finals, public voting*: Winners are selected by voting in the JunctionApp, finalists are auto-generated from the top-ranked projects in each challenge.
+
+*Finals, manual voting*: Winners are selected by voting in the JunctionApp, finalists are hand picked by organisers in the "Finalist selection" tab in "Projects".
+
+*No overall winner*: There is no single overall winner for this event and no voting happens for overall results.
+`}
                             error={form.errors[field.name]}
                             touched={form.touched[field.name]}
                         >

--- a/frontend/src/pages/_organise/slug/projects/finalist-selection/index.js
+++ b/frontend/src/pages/_organise/slug/projects/finalist-selection/index.js
@@ -1,0 +1,253 @@
+import React, { useState } from 'react'
+
+import {
+    Grid,
+    Box,
+    Dialog,
+    List,
+    ListItem,
+    ListItemIcon,
+    ListItemText,
+    Checkbox,
+    Button,
+    Paper,
+    Typography,
+} from '@material-ui/core'
+import * as SnackbarActions from 'redux/snackbar/actions'
+
+import { useDispatch, useSelector } from 'react-redux'
+
+import PageHeader from 'components/generic/PageHeader'
+import PageWrapper from 'components/layouts/PageWrapper'
+
+import * as OrganiserSelectors from 'redux/organiser/selectors'
+import * as AuthSelectors from 'redux/auth/selectors'
+
+import EventsService from 'services/events'
+
+import TextInput from 'components/inputs/TextInput'
+import { useDebounce } from 'hooks/customHooks'
+
+function not(a, b) {
+    return a.filter(value => b.indexOf(value) === -1)
+}
+
+function intersection(a, b) {
+    return a.filter(value => b.indexOf(value) !== -1)
+}
+
+export default () => {
+    const event = useSelector(OrganiserSelectors.event)
+    const projects = useSelector(OrganiserSelectors.projects)
+    const projectsMap = useSelector(OrganiserSelectors.projectsMap)
+    const dispatch = useDispatch()
+
+    const idToken = useSelector(AuthSelectors.getIdToken)
+    const [loading, setLoading] = useState(false)
+
+    const [checked, setChecked] = React.useState([])
+    const [left, setLeft] = React.useState([])
+    const [filteredLeft, setFilteredLeft] = React.useState([])
+
+    const [right, setRight] = React.useState([])
+    const [filter, setFilter] = React.useState('')
+    const debouncedFilter = useDebounce(filter, 300)
+
+    const leftChecked = intersection(checked, left)
+    const rightChecked = intersection(checked, right)
+
+    React.useEffect(() => {
+        const newLeft =
+            projects
+                ?.filter(project => !event?.finalists?.includes(project._id))
+                .map(project => project._id) || []
+        setLeft(newLeft)
+        setFilteredLeft(newLeft)
+        setRight(
+            projects
+                ?.filter(project => event?.finalists?.includes(project._id))
+                .map(project => project._id) || [],
+        )
+    }, [projects, event])
+
+    React.useEffect(() => {
+        if (debouncedFilter) {
+            const availableProjects = projects.filter(p => left.includes(p._id))
+            setFilteredLeft(
+                availableProjects
+                    ?.filter(
+                        project =>
+                            project.name
+                                ?.toLowerCase()
+                                .includes(debouncedFilter.toLowerCase()) ||
+                            project.punchline
+                                ?.toLowerCase()
+                                .includes(debouncedFilter.toLowerCase()),
+                    )
+                    .map(project => project._id) || [],
+            )
+        } else {
+            setFilteredLeft(left)
+        }
+    }, [debouncedFilter, left])
+
+    const handleToggle = value => () => {
+        const currentIndex = checked.indexOf(value)
+        const newChecked = [...checked]
+
+        if (currentIndex === -1) {
+            newChecked.push(value)
+        } else {
+            newChecked.splice(currentIndex, 1)
+        }
+
+        setChecked(newChecked)
+    }
+
+    const updateFinalists = projectIds => {
+        if (idToken && event?.slug) {
+            setLoading(true)
+            EventsService.batchUpdateFinalists(idToken, event.slug, projectIds)
+                .then(() => {
+                    dispatch(SnackbarActions.success('Finalists updated!'))
+                })
+                .catch(() => {
+                    dispatch(SnackbarActions.error('Oh no, an error happened.'))
+                })
+                .finally(() => {
+                    setLoading(false)
+                })
+        }
+    }
+
+    const handleCheckedRight = () => {
+        const newRight = right.concat(leftChecked)
+        setRight(newRight)
+        setLeft(not(left, leftChecked))
+        setChecked(not(checked, leftChecked))
+        updateFinalists(newRight)
+    }
+
+    const handleCheckedLeft = () => {
+        setLeft(left.concat(rightChecked))
+        const newRight = not(right, rightChecked)
+        setRight(newRight)
+        setChecked(not(checked, rightChecked))
+        updateFinalists(newRight)
+    }
+
+    const customList = items => (
+        <Paper>
+            <List
+                dense
+                component="div"
+                role="list"
+                style={{ maxHeight: 500, overflowY: 'auto' }}
+            >
+                {items.length === 0 && (
+                    <ListItem>
+                        <ListItemText
+                            primary={'Nothing added yet'}
+                            secondary={
+                                'Use the buttons to move projects to the finalists'
+                            }
+                        />
+                    </ListItem>
+                )}
+                {items.map(value => {
+                    const labelId = `transfer-list-item-${value}-label`
+
+                    return (
+                        <ListItem
+                            key={value}
+                            role="listitem"
+                            button
+                            onClick={handleToggle(value)}
+                        >
+                            <ListItemIcon>
+                                <Checkbox
+                                    checked={checked.indexOf(value) !== -1}
+                                    tabIndex={-1}
+                                    disableRipple
+                                    inputProps={{
+                                        'aria-labelledby': labelId,
+                                    }}
+                                />
+                            </ListItemIcon>
+                            <ListItemText
+                                id={labelId}
+                                primary={projectsMap[value]?.name}
+                                secondary={projectsMap[value]?.punchline}
+                            />
+                        </ListItem>
+                    )
+                })}
+                <ListItem />
+            </List>
+        </Paper>
+    )
+    return (
+        <PageWrapper>
+            <PageHeader
+                heading={''}
+                subheading="Select projects that people have made it to the finals. Competitors will be able to vote on projects that are in the 'Finalists'."
+            />
+            <Grid container spacing={2}>
+                <Grid item xs={5}>
+                    <Typography variant="h5">All projects</Typography>
+                    <Box style={{ marginBottom: 8 }}>
+                        <TextInput
+                            label="Filter"
+                            placeholder="Search by project name or punchline"
+                            onChange={value => setFilter(value)}
+                            value={filter}
+                        />
+                    </Box>
+
+                    {customList(filteredLeft)}
+                </Grid>
+                <Grid item xs={2} spacing={2}>
+                    <Grid
+                        container
+                        direction="column"
+                        style={{
+                            height: 300,
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                        }}
+                    >
+                        <Grid item>
+                            <Button
+                                variant="outlined"
+                                size="small"
+                                onClick={handleCheckedRight}
+                                disabled={leftChecked.length === 0 || loading}
+                                aria-label="move selected right"
+                            >
+                                -&gt;
+                            </Button>
+                        </Grid>
+                        <Grid item>
+                            <Button
+                                variant="outlined"
+                                size="small"
+                                onClick={handleCheckedLeft}
+                                disabled={rightChecked.length === 0 || loading}
+                                aria-label="move selected left"
+                            >
+                                &lt;-
+                            </Button>
+                        </Grid>
+                    </Grid>
+                </Grid>
+                <Grid item xs={5}>
+                    <Typography variant="h5" style={{ marginBottom: 48 }}>
+                        Finalists
+                    </Typography>
+
+                    {customList(right)}
+                </Grid>
+            </Grid>
+        </PageWrapper>
+    )
+}

--- a/frontend/src/pages/_organise/slug/projects/index.js
+++ b/frontend/src/pages/_organise/slug/projects/index.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react'
 
 import { useSelector } from 'react-redux'
 import { useRouteMatch, useLocation } from 'react-router'
+import { OverallReviewingMethods } from '@hackjunction/shared'
 
 import PageWrapper from 'components/layouts/PageWrapper'
 import MaterialTabsLayout from 'components/layouts/MaterialTabsLayout'
@@ -13,6 +14,7 @@ import TracksTab from './by-track'
 import GavelTab from './gavel'
 import AnnotatorsTab from './annotators'
 import WinnersTab from './winners'
+import FinalistSelectionTab from './finalist-selection'
 
 import * as OrganiserSelectors from 'redux/organiser/selectors'
 
@@ -62,6 +64,18 @@ export default () => {
             label: 'Gavel annotators',
             component: AnnotatorsTab,
         })
+
+        if (
+            event?.overallReviewMethod ===
+            OverallReviewingMethods.finalsManualSelection.id
+        ) {
+            data.push({
+                path: '/finalist-selection',
+                key: 'finalist-selection',
+                label: 'Finalist selection',
+                component: FinalistSelectionTab,
+            })
+        }
 
         data.push({
             path: '/winners',

--- a/frontend/src/pages/_pricing/index.js
+++ b/frontend/src/pages/_pricing/index.js
@@ -38,7 +38,7 @@ export default () => {
     const { t } = useTranslation()
     const body1 = [
         'Event registration and organization through platform.',
-        'For non - profit organizations.'
+        'For non - profit organizations.',
     ]
     const body2 = [
         'Event registration and organization through platform',

--- a/frontend/src/services/events.js
+++ b/frontend/src/services/events.js
@@ -98,6 +98,14 @@ EventsService.updateFinalists = (idToken, slug, projectId) => {
     )
 }
 
+EventsService.batchUpdateFinalists = (idToken, slug, projectIds) => {
+    return _axios.patch(
+        `${BASE_ROUTE}/${slug}/finalist/batch`,
+        { projectIds },
+        config(idToken),
+    )
+}
+
 EventsService.getFinalists = (idToken, slug) => {
     return _axios.get(`${BASE_ROUTE}/${slug}/finalist`, config(idToken))
 }


### PR DESCRIPTION
Another request from Crafthub was to improve the finalist selection UI. This PR adds a new tab to the "Projects" page that allows for simpler finalist selection. 

The projects are listed on the left and projects can be moved from the left to right to add them to finalists. Pressing either move button will update the finalists to the currently selected projects on the right.

There is a simple local filter option to search for projects based on their name or punchline.

<img width="1440" alt="image" src="https://user-images.githubusercontent.com/17903881/174432393-6014211c-5a39-40a1-abaf-e776a654793b.png">

I've also updated the messaging on the admin page to make each option clearer:
<img width="1108" alt="image" src="https://user-images.githubusercontent.com/17903881/174432711-49c48924-937b-4305-9301-980f9df26be7.png">
