### PR TITLE
feat: Add option to hide Banner on event landing page

### DIFF
--- a/frontend/src/pages/_events/slug/context.js
+++ b/frontend/src/pages/_events/slug/context.js
@@ -86,6 +86,7 @@ const eventQuery = gql`
                 sidebarTextColor
                 accentColor
                 linkColor
+                isLandingPageBannerHidden
             }
             _eventStatus
             _eventTimeFormatted

--- a/frontend/src/pages/_events/slug/default/EventButtons/index.js
+++ b/frontend/src/pages/_events/slug/default/EventButtons/index.js
@@ -10,7 +10,7 @@ import Button from 'components/generic/Button'
 import * as AuthSelectors from 'redux/auth/selectors'
 import { useTranslation } from 'react-i18next'
 
-export default ({ event, registration }) => {
+export default ({ event, registration, alignCenter }) => {
     const { t } = useTranslation()
     const dispatch = useDispatch()
     const match = useRouteMatch()
@@ -33,8 +33,16 @@ export default ({ event, registration }) => {
         case EventStatuses.REGISTRATION_OPEN.id: {
             if (isAuthenticated) {
                 if (hasRegistration) {
+                    const centerAlignAttributes = alignCenter
+                        ? {
+                              direction: 'column',
+                              justifyContent: 'center',
+                              alignItems: 'center',
+                          }
+                        : undefined
+
                     return (
-                        <Grid container spacing={1}>
+                        <Grid container spacing={1} {...centerAlignAttributes}>
                             <Grid item xs={12}>
                                 <Button
                                     onClick={() =>

--- a/frontend/src/pages/_events/slug/default/index.js
+++ b/frontend/src/pages/_events/slug/default/index.js
@@ -203,11 +203,12 @@ export default () => {
                         <EventButtons
                             event={event}
                             registration={registration}
+                            alignCenter
                         />
                     </Box>
                 </StaggeredList>
             </FadeInWrapper>
-            <BannerCarousel />
+            {!event.theme.isLandingPageBannerHidden && <BannerCarousel />}
         </>
     )
 }

--- a/frontend/src/pages/_organise/slug/edit/default/const.js
+++ b/frontend/src/pages/_organise/slug/edit/default/const.js
@@ -8,4 +8,5 @@ export const defaultEventStyles = {
     sidebarTextColor: '#000000',
     accentColor: '#73f9ec',
     linkColor: '#52d7af',
+    isLandingPageBannerHidden: false,
 }

--- a/frontend/src/pages/_organise/slug/edit/default/index.js
+++ b/frontend/src/pages/_organise/slug/edit/default/index.js
@@ -9,6 +9,7 @@ import FormControl from 'components/inputs/FormControl'
 import TextInput from 'components/inputs/TextInput'
 import ImageUpload from 'components/inputs/ImageUpload'
 import Select from 'components/inputs/Select'
+import BooleanInput from 'components/inputs/BooleanInput'
 
 import * as OrganiserSelectors from 'redux/organiser/selectors'
 import { useAllOrganizations } from 'graphql/queries/organization'
@@ -17,7 +18,7 @@ import Button from 'components/generic/Button'
 import { push } from 'connected-react-router'
 import { defaultEventStyles } from './const'
 
-const themeFields = [
+const colorThemeFields = [
     {
         field: 'headerBackgroundColor',
         label: 'Header background',
@@ -320,7 +321,7 @@ export default () => {
             </Grid>
             <Grid item xs={12}>
                 <Grid container spacing={5}>
-                    {themeFields.map(themeField => (
+                    {colorThemeFields.map(themeField => (
                         <Grid
                             item
                             xs={12}
@@ -352,6 +353,29 @@ export default () => {
                             />
                         </Grid>
                     ))}
+                    <Grid item xs={12}>
+                        <FastField
+                            name="theme.isLandingPageBannerHidden"
+                            render={({ field, form }) => (
+                                <FormControl
+                                    label="Hide Junction banner on landing page"
+                                    hint="The banner displays information regarding the JunctionApp or other platform related news."
+                                    error={form.errors[field.name]}
+                                    touched={form.touched[field.name]}
+                                >
+                                    <BooleanInput
+                                        value={field.value}
+                                        onChange={value =>
+                                            form.setFieldValue(
+                                                field.name,
+                                                value,
+                                            )
+                                        }
+                                    />
+                                </FormControl>
+                            )}
+                        />
+                    </Grid>
                     <Grid item xs={12}>
                         <Button
                             variant="contained"

--- a/shared/schemas/EventTheme.js
+++ b/shared/schemas/EventTheme.js
@@ -5,6 +5,7 @@ const {
     GraphQLNonNull,
     GraphQLInputObjectType,
 } = require('graphql')
+const { GraphQLBoolean } = require('graphql')
 
 const EventThemeSchema = new mongoose.Schema({
     headerBackgroundColor: {
@@ -43,6 +44,10 @@ const EventThemeSchema = new mongoose.Schema({
         type: String,
         default: '#52d7af',
     },
+    isLandingPageBannerHidden: {
+        type: Boolean,
+        default: false,
+    },
 })
 
 const EventThemeInput = new GraphQLInputObjectType({
@@ -78,6 +83,9 @@ const EventThemeInput = new GraphQLInputObjectType({
         linkColor: {
             type: GraphQLNonNull(GraphQLString),
         },
+        isLandingPageBannerHidden: {
+            type: GraphQLNonNull(GraphQLBoolean),
+        },
     },
 })
 
@@ -110,6 +118,9 @@ const EventThemeType = new GraphQLObjectType({
         },
         linkColor: {
             type: GraphQLNonNull(GraphQLString),
+        },
+        isLandingPageBannerHidden: {
+            type: GraphQLNonNull(GraphQLBoolean),
         },
     },
 })


### PR DESCRIPTION
Adds a new option to the event customization options that allows hiding the Banner visible on the bottom of the event landing page.

I decided to place this under the "eventTheme" field as this relates to the customization/theming of the landing page. In a future refactor, this field could be better separated to a "colors" and other sub-objects. 

In the future, this new option could be a paying feature as well, only allowed for certain organizations.

<img width="1112" alt="image" src="https://user-images.githubusercontent.com/17903881/189182521-b50302cb-bb2c-41f2-a374-d71dd4511f73.png">


Page without banner:
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/17903881/189182845-0b880d00-c85e-42f7-afd8-0db1fe80d4b1.png">


