### PR TITLE
fix: Link colors are sometimes incorrect

### DIFF
--- a/frontend/src/pages/_events/slug/default/index.js
+++ b/frontend/src/pages/_events/slug/default/index.js
@@ -45,7 +45,7 @@ const useStyles = makeStyles({
     },
     body: {
         background: props => props.bodyBackgroundColor,
-        '& a>p': {
+        '& a *': {
             color: props => props.linkColor,
         },
     },


### PR DESCRIPTION
Small rendering fix for links that are not direct `p` children of an anchor tag.