### PR TITLE
Improve project and teams exports

### DIFF
--- a/backend/modules/project/controller.js
+++ b/backend/modules/project/controller.js
@@ -4,6 +4,7 @@ const Promise = require('bluebird')
 const { ProjectSchema } = require('@hackjunction/shared')
 const Project = require('./model')
 const { ForbiddenError } = require('../../common/errors/errors')
+const TeamController = require('../team/controller')
 
 const controller = {}
 
@@ -179,4 +180,32 @@ controller.getFinalProjects = async event => {
     return projects
 }
 
+controller.exportProjects = async projectIds => {
+    let projects = await Project.find({ _id: { $in: projectIds } }).populate({
+        path: 'team',
+    })
+
+    const projectAndMeta = await Promise.all(
+        projects.map(async project => {
+            const teamWithMeta = await TeamController.attachMeta(project.team)
+            return [project, teamWithMeta]
+        }),
+    )
+
+    const exportData = projectAndMeta.map(([project, teamWithMeta]) => {
+        return {
+            ...project.getExportData(),
+            teamCode: teamWithMeta.code,
+            teamMembers: Object.values(teamWithMeta.meta)
+                .map(memberMeta => memberMeta.profile)
+                .map(
+                    memberProfile =>
+                        `${memberProfile.firstName} ${memberProfile.lastName} <${memberProfile.email}>`,
+                )
+                .join(', '),
+        }
+    })
+
+    return exportData
+}
 module.exports = controller

--- a/backend/modules/project/controller.js
+++ b/backend/modules/project/controller.js
@@ -195,14 +195,7 @@ controller.exportProjects = async projectIds => {
     const exportData = projectAndMeta.map(([project, teamWithMeta]) => {
         return {
             ...project.getExportData(),
-            teamCode: teamWithMeta.code,
-            teamMembers: Object.values(teamWithMeta.meta)
-                .map(memberMeta => memberMeta.profile)
-                .map(
-                    memberProfile =>
-                        `${memberProfile.firstName} ${memberProfile.lastName} <${memberProfile.email}>`,
-                )
-                .join(', '),
+            ...TeamController.convertToFlatExportData(teamWithMeta),
         }
     })
 

--- a/backend/modules/project/model.js
+++ b/backend/modules/project/model.js
@@ -89,6 +89,23 @@ ProjectSchema.methods.getPreview = function () {
     return _.omit(this, ['description'])
 }
 
+ProjectSchema.methods.getExportData = function () {
+    return {
+        name: this.name || '',
+        punchline: this.punchline || '',
+        description: this.description || '',
+        technologies: this.technologies.join(', ') || '',
+        source: this.source || '',
+        demo: this.demo || '',
+        images: this.images.map(image => image.url).join(', ') || '',
+        challenges: this.challenges.join(', ') || '',
+        track: this.track || '',
+        location: this.location || '',
+        status: this.status || '',
+        video: this.video || '',
+    }
+}
+
 ProjectSchema.post('save', async function (doc, next) {
     const event = await mongoose.model('Event').findById(this.event)
     switch (event.reviewMethod) {

--- a/backend/modules/project/routes.js
+++ b/backend/modules/project/routes.js
@@ -57,11 +57,12 @@ router
         isAfter.submissionsStartTime,
         isBefore.submissionsEndTime,
         asyncHandler(async (req, res) => {
-            const project = await ProjectController.createProjectForEventAndTeam(
-                req.event,
-                req.team,
-                req.body.data,
-            )
+            const project =
+                await ProjectController.createProjectForEventAndTeam(
+                    req.event,
+                    req.team,
+                    req.body.data,
+                )
             return res.status(200).json(project)
         }),
     )
@@ -72,11 +73,12 @@ router
         isAfter.submissionsStartTime,
         isBefore.submissionsEndTime,
         asyncHandler(async (req, res) => {
-            const project = await ProjectController.updateProjectForEventAndTeam(
-                req.event,
-                req.team,
-                req.body.data,
-            )
+            const project =
+                await ProjectController.updateProjectForEventAndTeam(
+                    req.event,
+                    req.team,
+                    req.body.data,
+                )
             return res.status(200).json(project)
         }),
     )
@@ -116,10 +118,11 @@ router
     .get(
         getEventFromParams,
         asyncHandler(async (req, res) => {
-            const projects = await ProjectController.getChallengeProjectsWithToken(
-                req.event,
-                req.params.token,
-            )
+            const projects =
+                await ProjectController.getChallengeProjectsWithToken(
+                    req.event,
+                    req.params.token,
+                )
             return res.status(200).json(projects)
         }),
     )
@@ -162,6 +165,20 @@ router
             const projects = await ProjectController.validateToken(
                 req.event,
                 req.params.token,
+            )
+            return res.status(200).json(projects)
+        }),
+    )
+
+router
+    .route('/:slug/admin/export')
+    /** As an event admin, export selected projects */
+    .post(
+        hasToken,
+        isEventOrganiser,
+        asyncHandler(async (req, res) => {
+            const projects = await ProjectController.exportProjects(
+                req.body.projectIds,
             )
             return res.status(200).json(projects)
         }),

--- a/backend/modules/team/controller.js
+++ b/backend/modules/team/controller.js
@@ -200,4 +200,26 @@ controller.getTeamStatsForEvent = async eventId => {
     }
 }
 
+controller.exportTeams = async teamIds => {
+    const teams = await Team.find({ _id: { $in: teamIds } })
+    const teamsWithMeta = await Promise.all(
+        teams.map(team => controller.attachMeta(team)),
+    )
+
+    return teamsWithMeta.map(controller.convertToFlatExportData)
+}
+
+controller.convertToFlatExportData = teamWithMeta => {
+    return {
+        teamCode: teamWithMeta.code,
+        teamMembers: Object.values(teamWithMeta.meta)
+            .map(memberMeta => memberMeta.profile)
+            .map(
+                memberProfile =>
+                    `${memberProfile.firstName} ${memberProfile.lastName} <${memberProfile.email}>`,
+            )
+            .join(', '),
+    }
+}
+
 module.exports = controller

--- a/backend/modules/team/routes.js
+++ b/backend/modules/team/routes.js
@@ -31,7 +31,7 @@ const editTeam = asyncHandler(async (req, res) => {
     const team = await TeamController.editTeam(
         req.event._id,
         req.user.sub,
-        req.body
+        req.body,
     )
     return res.status(200).json(team)
 })
@@ -40,7 +40,7 @@ const joinTeam = asyncHandler(async (req, res) => {
     let team = await TeamController.joinTeam(
         req.event._id,
         req.user.sub,
-        req.params.code
+        req.params.code,
     )
     if (req.query.populate === 'true') {
         team = await TeamController.attachMeta(team)
@@ -57,7 +57,7 @@ const removeMember = asyncHandler(async (req, res) => {
     const team = await TeamController.removeMemberFromTeam(
         req.event._id,
         req.user.sub,
-        req.params.userId
+        req.params.userId,
     )
     return res.status(200).json(team)
 })
@@ -65,7 +65,7 @@ const removeMember = asyncHandler(async (req, res) => {
 const getTeam = asyncHandler(async (req, res) => {
     let team = await TeamController.getTeam(
         req.event._id.toString(),
-        req.user.sub
+        req.user.sub,
     )
     if (req.query.populate === 'true') {
         team = await TeamController.attachMeta(team)
@@ -78,6 +78,11 @@ const getTeamsForEvent = asyncHandler(async (req, res) => {
     return res.status(200).json(teams)
 })
 
+const exportTeams = asyncHandler(async (req, res) => {
+    const teams = await TeamController.exportTeams(req.body.teamIds)
+    return res.status(200).json(teams)
+})
+
 /** Organiser routes */
 router
     .route('/organiser/:slug')
@@ -85,7 +90,16 @@ router
         hasToken,
         hasPermission(Auth.Permissions.MANAGE_EVENT),
         isEventOrganiser,
-        getTeamsForEvent
+        getTeamsForEvent,
+    )
+
+router
+    .route('/organiser/:slug/export')
+    .post(
+        hasToken,
+        hasPermission(Auth.Permissions.MANAGE_EVENT),
+        isEventOrganiser,
+        exportTeams,
     )
 
 /** User-facing routes */
@@ -96,19 +110,19 @@ router
         hasToken,
         hasRegisteredToEvent,
         isBefore.submissionsEndTime,
-        createTeam
+        createTeam,
     )
     .patch(
         hasToken,
         hasRegisteredToEvent,
         isBefore.submissionsEndTime,
-        editTeam
+        editTeam,
     )
     .delete(
         hasToken,
         hasRegisteredToEvent,
         isBefore.submissionsEndTime,
-        deleteTeam
+        deleteTeam,
     )
 
 router
@@ -118,7 +132,7 @@ router
         hasToken,
         hasRegisteredToEvent,
         isBefore.submissionsEndTime,
-        leaveTeam
+        leaveTeam,
     )
 
 router
@@ -127,7 +141,7 @@ router
         hasToken,
         hasRegisteredToEvent,
         isBefore.submissionsEndTime,
-        removeMember
+        removeMember,
     )
 
 module.exports = router

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
         "cloudinary-react": "^1.5.0",
         "connected-react-router": "^6.8.0",
         "downloadjs": "^1.4.7",
+        "export-to-csv": "^0.2.1",
         "formik": "^2.1.4",
         "framer-motion": "^1.11.0",
         "graphql": "^15.0.0",

--- a/frontend/src/components/tables/ProjectsTable/index.js
+++ b/frontend/src/components/tables/ProjectsTable/index.js
@@ -109,8 +109,8 @@ const ProjectsTable = ({ projects, baseURL }) => {
                         key: 'export-projects',
                         label: 'Export selected',
                         action: rows => {
-                            const newRows = rows.map(row => row.original._id)
-                            fetchExportProjectData(newRows)
+                            const projectIds = rows.map(row => row.original._id)
+                            fetchExportProjectData(projectIds)
                         },
                     },
                 ]}

--- a/frontend/src/services/csvExporter.js
+++ b/frontend/src/services/csvExporter.js
@@ -1,0 +1,15 @@
+import { ExportToCsv } from 'export-to-csv'
+
+const CsvExporterService = {}
+
+CsvExporterService.exportToCsv = (data, fileName) => {
+    const options = {
+        filename: fileName,
+        useKeysAsHeaders: true,
+    }
+
+    const csvExporter = new ExportToCsv(options)
+    csvExporter.generateCsv(data)
+}
+
+export default CsvExporterService

--- a/frontend/src/services/projects.js
+++ b/frontend/src/services/projects.js
@@ -71,4 +71,13 @@ ProjectsService.getCommits = projectId => {
     return project
 }
 
+ProjectsService.exportProjects = (idToken, eventSlug, projectIds) => {
+    const projects = _axios.post(
+        `/projects/${eventSlug}/admin/export`,
+        { projectIds },
+        config(idToken),
+    )
+    return projects
+}
+
 export default ProjectsService

--- a/frontend/src/services/teams.js
+++ b/frontend/src/services/teams.js
@@ -14,6 +14,14 @@ TeamsService.getTeamsForEvent = (idToken, eventSlug) => {
     return _axios.get(`/teams/organiser/${eventSlug}`, config(idToken))
 }
 
+TeamsService.exportTeams = (idToken, eventSlug, teamIds) => {
+    return _axios.post(
+        `/teams/organiser/${eventSlug}/export`,
+        { teamIds },
+        config(idToken),
+    )
+}
+
 TeamsService.createTeamForEvent = (idToken, eventSlug, populate) => {
     return _axios.post(
         `/teams/${eventSlug}?populate=${populate}`,


### PR DESCRIPTION
Copy of https://github.com/hackjunction/JunctionApp/pull/542

Exporting data currently relies on the actual rows and columns displayed in a data table. This is sometimes not desired, when organisers want to have a "full" export of useful, valuable data from projects and teams. This PR adds two new backend routes that format projects and events into a flat, CSV-compatible structure that the frontend can load on demand before downloading it as a .csv file.

I've added a new library for exporting CSVs on-demand. I've struggled to make the existing React-flavored CSVLink to work with on-demand data (see this bug thread) so I've added a new library to generate and download the csv files.

New button on Teams tab to export teams with members:
![image](https://user-images.githubusercontent.com/17903881/190926253-1052f29b-0e4a-4f37-8ded-23f5f1199266.png)
Exported CSV (members is a comma separated list, only one member in test)
![image](https://user-images.githubusercontent.com/17903881/190926257-490f0d8a-c70f-4a71-8d11-5f3fb8af1022.png)


Existing button, but logic replaced with full data export for projects, not just the visible columns:
![image](https://user-images.githubusercontent.com/17903881/190926263-98723b08-b3d5-41e3-9d6d-6e56a37132d5.png)

Exported CSV with all project fields:
![image](https://user-images.githubusercontent.com/17903881/190926266-890b37ea-3d2a-4750-bdc0-428036fb7532.png)