### PR TITLE
feat: Add option to hide Banner on event landing page

### DIFF
--- a/frontend/src/components/events/EventHeroImage/index.js
+++ b/frontend/src/components/events/EventHeroImage/index.js
@@ -18,7 +18,6 @@ const useStyles = makeStyles(theme => ({
     },
     imageContainer: {
         display: 'flex',
-
     },
     image: {
         zIndex: 1,

--- a/frontend/src/pages/_events/slug/context.js
+++ b/frontend/src/pages/_events/slug/context.js
@@ -63,6 +63,7 @@ const eventQuery = gql`
                 sidebarTextColor
                 accentColor
                 linkColor
+                isLandingPageBannerHidden
             }
             pageScripts {
                 page

--- a/frontend/src/pages/_events/slug/default/EventButtons/index.js
+++ b/frontend/src/pages/_events/slug/default/EventButtons/index.js
@@ -10,7 +10,7 @@ import Button from 'components/generic/Button'
 import * as AuthSelectors from 'redux/auth/selectors'
 import { useTranslation } from 'react-i18next'
 
-export default ({ event, registration }) => {
+export default ({ event, registration, alignCenter }) => {
     const { t } = useTranslation()
     const dispatch = useDispatch()
     const match = useRouteMatch()
@@ -33,8 +33,16 @@ export default ({ event, registration }) => {
         case EventStatuses.REGISTRATION_OPEN.id: {
             if (isAuthenticated) {
                 if (hasRegistration) {
+                    const centerAlignAttributes = alignCenter
+                        ? {
+                              direction: 'column',
+                              justifyContent: 'center',
+                              alignItems: 'center',
+                          }
+                        : undefined
+
                     return (
-                        <Grid container spacing={1}>
+                        <Grid container spacing={1} {...centerAlignAttributes}>
                             <Grid item xs={12}>
                                 <Button
                                     onClick={() =>

--- a/frontend/src/pages/_events/slug/default/index.js
+++ b/frontend/src/pages/_events/slug/default/index.js
@@ -199,11 +199,12 @@ export default () => {
                         <EventButtons
                             event={event}
                             registration={registration}
+                            alignCenter
                         />
                     </Box>
                 </StaggeredList>
             </FadeInWrapper>
-            <BannerCarousel />
+            {!event.theme.isLandingPageBannerHidden && <BannerCarousel />}
             <EventPageScriptIFrame
                 slug={slug}
                 pageId={EventPageScripts.PageScriptLocation.EVENT_DETAILS_PAGE}

--- a/frontend/src/pages/_organise/slug/edit/default/const.js
+++ b/frontend/src/pages/_organise/slug/edit/default/const.js
@@ -8,4 +8,5 @@ export const defaultEventStyles = {
     sidebarTextColor: '#000000',
     accentColor: '#73f9ec',
     linkColor: '#52d7af',
+    isLandingPageBannerHidden: false,
 }

--- a/frontend/src/pages/_organise/slug/edit/default/index.js
+++ b/frontend/src/pages/_organise/slug/edit/default/index.js
@@ -9,6 +9,7 @@ import FormControl from 'components/inputs/FormControl'
 import TextInput from 'components/inputs/TextInput'
 import ImageUpload from 'components/inputs/ImageUpload'
 import Select from 'components/inputs/Select'
+import BooleanInput from 'components/inputs/BooleanInput'
 
 import * as OrganiserSelectors from 'redux/organiser/selectors'
 import { useAllOrganizations } from 'graphql/queries/organization'
@@ -17,7 +18,7 @@ import Button from 'components/generic/Button'
 import { push } from 'connected-react-router'
 import { defaultEventStyles } from './const'
 
-const themeFields = [
+const colorThemeFields = [
     {
         field: 'headerBackgroundColor',
         label: 'Header background',
@@ -320,7 +321,7 @@ export default () => {
             </Grid>
             <Grid item xs={12}>
                 <Grid container spacing={5}>
-                    {themeFields.map(themeField => (
+                    {colorThemeFields.map(themeField => (
                         <Grid
                             item
                             xs={12}
@@ -352,6 +353,29 @@ export default () => {
                             />
                         </Grid>
                     ))}
+                    <Grid item xs={12}>
+                        <FastField
+                            name="theme.isLandingPageBannerHidden"
+                            render={({ field, form }) => (
+                                <FormControl
+                                    label="Hide Junction banner on landing page"
+                                    hint="The banner displays information regarding the JunctionApp or other platform related news."
+                                    error={form.errors[field.name]}
+                                    touched={form.touched[field.name]}
+                                >
+                                    <BooleanInput
+                                        value={field.value}
+                                        onChange={value =>
+                                            form.setFieldValue(
+                                                field.name,
+                                                value,
+                                            )
+                                        }
+                                    />
+                                </FormControl>
+                            )}
+                        />
+                    </Grid>
                     <Grid item xs={12}>
                         <Button
                             variant="contained"

--- a/frontend/src/pages/_organise/slug/stats/index.js
+++ b/frontend/src/pages/_organise/slug/stats/index.js
@@ -23,7 +23,7 @@ export default () => {
         '/embed/dashboard/' +
         token +
         '#bordered=true&titled=true'
-    
+
     return (
         <PageWrapper>
             <PageHeader

--- a/shared/schemas/EventTheme.js
+++ b/shared/schemas/EventTheme.js
@@ -50,45 +50,6 @@ const EventThemeSchema = new mongoose.Schema({
     },
 })
 
-const EventThemeInput = new GraphQLInputObjectType({
-    name: 'EventThemeInput',
-    fields: {
-        _id: {
-            type: GraphQLString,
-        },
-        headerBackgroundColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        headerTextColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        bodyBackgroundColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        detailsBackgroundColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        detailsTextColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        sidebarBackgroundColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        sidebarTextColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        accentColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        linkColor: {
-            type: GraphQLNonNull(GraphQLString),
-        },
-        isLandingPageBannerHidden: {
-            type: GraphQLNonNull(GraphQLBoolean),
-        },
-    },
-})
-
 const EventThemeType = new GraphQLObjectType({
     name: 'EventTheme',
     fields: {

--- a/shared/schemas/EventTheme.js
+++ b/shared/schemas/EventTheme.js
@@ -1,5 +1,11 @@
 const mongoose = require('mongoose')
-const { GraphQLObjectType, GraphQLString, GraphQLNonNull } = require('graphql')
+const {
+    GraphQLObjectType,
+    GraphQLString,
+    GraphQLNonNull,
+    GraphQLInputObjectType,
+} = require('graphql')
+const { GraphQLBoolean } = require('graphql')
 
 const EventThemeSchema = new mongoose.Schema({
     headerBackgroundColor: {
@@ -38,6 +44,49 @@ const EventThemeSchema = new mongoose.Schema({
         type: String,
         default: '#52d7af',
     },
+    isLandingPageBannerHidden: {
+        type: Boolean,
+        default: false,
+    },
+})
+
+const EventThemeInput = new GraphQLInputObjectType({
+    name: 'EventThemeInput',
+    fields: {
+        _id: {
+            type: GraphQLString,
+        },
+        headerBackgroundColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        headerTextColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        bodyBackgroundColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        detailsBackgroundColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        detailsTextColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        sidebarBackgroundColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        sidebarTextColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        accentColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        linkColor: {
+            type: GraphQLNonNull(GraphQLString),
+        },
+        isLandingPageBannerHidden: {
+            type: GraphQLNonNull(GraphQLBoolean),
+        },
+    },
 })
 
 const EventThemeType = new GraphQLObjectType({
@@ -69,6 +118,9 @@ const EventThemeType = new GraphQLObjectType({
         },
         linkColor: {
             type: GraphQLNonNull(GraphQLString),
+        },
+        isLandingPageBannerHidden: {
+            type: GraphQLNonNull(GraphQLBoolean),
         },
     },
 })


### PR DESCRIPTION
Copy of https://github.com/hackjunction/JunctionApp/pull/558

Adds a new option to the event customization options that allows hiding the Banner visible on the bottom of the event landing page.

I decided to place this under the "eventTheme" field as this relates to the customization/theming of the landing page. In a future refactor, this field could be better separated to a "colors" and other sub-objects.

In the future, this new option could be a paying feature as well, only allowed for certain organizations.

![image](https://user-images.githubusercontent.com/17903881/190926306-40a6da04-2849-437a-8a4e-c0e9b1fb9018.png)

Page without banner:
![image](https://user-images.githubusercontent.com/17903881/190926308-13b066ec-46db-4dd2-8a20-d69533e8300b.png)